### PR TITLE
Fix changelog syntax and day

### DIFF
--- a/akmods-keys.spec
+++ b/akmods-keys.spec
@@ -50,8 +50,8 @@ install -pm 0640 %{SOURCE2} %{buildroot}%{_sysconfdir}/rpm/
 %attr(0644,root,root) %{_sysconfdir}/rpm/macros.kmodtool
 
 %changelog
-* Mon June 28 2022 Christian Mainka <Christian.Mainka@rub.de> - 0.0.2
+* Tue Jun 28 2022 Christian Mainka <Christian.Mainka@rub.de> - 0.0.2
 - Used macros.kmodtool to avoid filename conflicts
 
-* Mon June 27 2022 Christian Mainka <Christian.Mainka@rub.de> - 0.0.1
+* Mon Jun 27 2022 Christian Mainka <Christian.Mainka@rub.de> - 0.0.1
 - First Version


### PR DESCRIPTION
On my Silverblue 37 beta system, I get warnings about the notation of the changelog. First, the months seem to have to be three letters, and secondly it seems to check if the day is actually correct, which is not the case for June 28 of this year.

This change got rid of the errors for me. I haven't tried this on Silverblue 36.